### PR TITLE
Put in correct module name for BorutaPyPlus

### DIFF
--- a/boruta/__init__.py
+++ b/boruta/__init__.py
@@ -1,2 +1,2 @@
 from .boruta_py import  BorutaPy
-from .boruta_py2 import BorutaPyPlus
+from .boruta_py_plus import BorutaPyPlus


### PR DESCRIPTION
Fixes import error because boruta_py2.py doesn't exist anymore.