### PR TITLE
fixed setup.py requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ __verbose__ : int, default=0
 
     import pandas as pd
     from sklearn.ensemble import RandomForestClassifier
-    from boruta_py import BorutaPy
+    from boruta import BorutaPy
 
     # load X and y
     # NOTE BorutaPy accepts numpy arrays only, hence the .values attribute

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(name='Boruta',
       license='BSD 3 clause',
       packages=['boruta'],
       zip_safe=False,
-      install_requires=['numpy==1.10.4',
-                        'scikit-learn==0.17.1',
-                        'scipy==0.17.0'
+      install_requires=['numpy>=1.10.4',
+                        'scikit-learn>=0.17.1',
+                        'scipy>=0.17.0'
                         ])


### PR DESCRIPTION
Just had to reinstall, noticed setup.py hard coded to some older versions of scipy, numpy, sklearn.

This PR updates setup.py such that it requires at least those versions, rather than exactly those versions.
