### PR TITLE
Specify dependencies without pinning versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(name='Boruta',
       license='BSD 3 clause',
       packages=['boruta'],
       zip_safe=False,
-      install_requires=['numpy==1.10.4',
-                        'scikit-learn==0.17.1',
-                        'scipy==0.17.0'
+      install_requires=['numpy>=1.10.4',
+                        'scikit-learn>=0.17.1',
+                        'scipy>=0.17.0'
                         ])


### PR DESCRIPTION
This package looks great! Would it be possible to switch these dependencies to be minimums, rather than exact version numbers? Otherwise, if you have the nightlies of `sklearn` etc installed, `pip` will want to downgrade them.